### PR TITLE
feat: Add support for custom MAC addresses

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,8 +42,9 @@ resource "proxmox_virtual_environment_vm" "talos_control_vm" {
         size         = var.proxmox_control_vm_disk_size
     }
     network_device {
-        vlan_id = var.proxmox_network_vlan_id
-        bridge  = var.proxmox_network_bridge
+        vlan_id     = var.proxmox_network_vlan_id
+        bridge      = var.proxmox_network_bridge
+        mac_address = lookup(var.control_plane_mac_addresses, each.key, null)
     }
     operating_system {
         type = "l26"
@@ -74,8 +75,9 @@ resource "proxmox_virtual_environment_vm" "talos_worker_vm" {
         size         = var.proxmox_worker_vm_disk_size
     }
     network_device {
-        vlan_id = var.proxmox_network_vlan_id
-        bridge  = var.proxmox_network_bridge
+        vlan_id     = var.proxmox_network_vlan_id
+        bridge      = var.proxmox_network_bridge
+        mac_address = lookup(var.worker_mac_addresses, each.key, null)
     }
     dynamic "disk" {
         for_each = lookup(var.worker_extra_disks, each.key, [])

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,3 +11,18 @@ output "kubeconfig" {
     value       = talos_cluster_kubeconfig.talos_kubeconfig.kubeconfig_raw
     sensitive   = true
 }
+
+output "control_plane_ips" {
+    description = "List of control plane node IPs"
+    value       = local.control_node_ips
+}
+
+output "worker_ips" {
+    description = "List of worker node IPs"
+    value       = local.worker_node_ips
+}
+
+output "all_node_ips" {
+    description = "List of all node IPs (control + workers)"
+    value       = local.node_ips
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,20 @@ variable "proxmox_network_bridge" {
   default = "vmbr0"
 }
 
+variable "control_plane_mac_addresses" {
+    description = "Map of control plane node names to MAC addresses for static IP assignment via DHCP"
+    type        = map(string)
+    default     = {}
+    nullable    = false
+}
+
+variable "worker_mac_addresses" {
+    description = "Map of worker node names to MAC addresses for static IP assignment via DHCP"
+    type        = map(string)
+    default     = {}
+    nullable    = false
+}
+
 variable "talos_cluster_name" {
     description = "Name of the Talos cluster"
     type        = string


### PR DESCRIPTION
## Summary
- Add `control_plane_mac_addresses` variable for static DHCP IP assignment on control plane nodes
- Add `worker_mac_addresses` variable for static DHCP IP assignment on worker nodes
- Update `network_device` blocks to use custom MAC addresses when provided

This allows users to assign predictable IP addresses via DHCP reservations by specifying MAC addresses for each node.

## Example Usage
```hcl
module "talos" {
  source  = "bbtechsys/talos/proxmox"
  
  control_plane_mac_addresses = {
    "cp-1" = "bc:24:11:00:00:01"
    "cp-2" = "bc:24:11:00:00:02"
  }
  
  worker_mac_addresses = {
    "w-1" = "bc:24:11:00:00:03"
  }
}
```