### PR TITLE
feat: Add node IP outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -11,3 +11,18 @@ output "kubeconfig" {
     value       = talos_cluster_kubeconfig.talos_kubeconfig.kubeconfig_raw
     sensitive   = true
 }
+
+output "control_plane_ips" {
+    description = "List of control plane node IPs"
+    value       = local.control_node_ips
+}
+
+output "worker_ips" {
+    description = "List of worker node IPs"
+    value       = local.worker_node_ips
+}
+
+output "all_node_ips" {
+    description = "List of all node IPs (control + workers)"
+    value       = local.node_ips
+}


### PR DESCRIPTION
## Summary
Add `control_plane_ips`, `worker_ips`, and `all_node_ips` outputs to allow other resources to reference the assigned node IPs.

## Example Usage
```hcl
module "talos" {
  source  = "bbtechsys/talos/proxmox"
}

# Use the control plane IP for DNS
resource "some_dns_provider_record" "kube_api" {
  domain = "kube.local"
  ip     = module.talos.control_plane_ips[0]
}
```