### PR TITLE
fix: replace deprecated proxmox_virtual_environment_download_file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Calculate Version
+        id: version
+        uses: PaulHatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(feat)"
+          version_format: "${major}.${minor}.${patch}"
+      
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes || \
+          echo "Release v${{ steps.version.outputs.version }} already exists, exiting gracefully" && exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Auto Release
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "**.tf"
 
 permissions:
   contents: write
@@ -20,8 +22,12 @@ jobs:
         uses: PaulHatch/semantic-version@v5.4.0
         with:
           tag_prefix: "v"
-          major_pattern: "(MAJOR)"
-          minor_pattern: "(feat)"
+          major_pattern: "(major)"
+          # "Default to minor" strategy:
+          # If it matches "fix" or "hotfix", it's a PATCH.
+          # If it does NOT match those, it's a MINOR.
+          minor_pattern: "^((?!fix|hotfix).)*$"
+          patch_pattern: "(fix|hotfix)"
           version_format: "${major}.${minor}.${patch}"
       
       - name: Create Release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+*.terraform.lock.hcl
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore pre-commit compiled binaries and tools
+terraform-docs
+terraform-docs.tar.gz
+
+# Ignore virtualenv
+.venv/
+venv/
+ENV/
+env/
+
+# Ignore custom tools directory
+_tools/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.97.0 # Get the latest from https://github.com/antonbabenko/pre-commit-terraform/releases
+    hooks:
+      - id: terraform_docs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 BB Tech Systems LLC
+Copyright (c) 2018 The terraform-docs Authors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -61,3 +61,71 @@ output "kubeconfig" {
 Check out our [blog post](https://bbtechsystems.com/blog/k8s-with-pxe-tf/) for more details on using this module.
 
 Copyright (c) 2024 BB Tech Systems LLC
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_proxmox"></a> [proxmox](#requirement\_proxmox) | >= 0.68.0 |
+| <a name="requirement_talos"></a> [talos](#requirement\_talos) | >= 0.6.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_proxmox"></a> [proxmox](#provider\_proxmox) | >= 0.68.0 |
+| <a name="provider_talos"></a> [talos](#provider\_talos) | >= 0.6.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [proxmox_virtual_environment_download_file.talos_image](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_download_file) | resource |
+| [proxmox_virtual_environment_vm.talos_control_vm](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm) | resource |
+| [proxmox_virtual_environment_vm.talos_worker_vm](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm) | resource |
+| [talos_cluster_kubeconfig.talos_kubeconfig](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/resources/cluster_kubeconfig) | resource |
+| [talos_machine_bootstrap.talos_bootstrap](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/resources/machine_bootstrap) | resource |
+| [talos_machine_configuration_apply.talos_control_mc_apply](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/resources/machine_configuration_apply) | resource |
+| [talos_machine_configuration_apply.talos_worker_mc_apply](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/resources/machine_configuration_apply) | resource |
+| [talos_machine_secrets.talos_secrets](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/resources/machine_secrets) | resource |
+| [talos_client_configuration.talos_client_config](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/data-sources/client_configuration) | data source |
+| [talos_machine_configuration.control_mc](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/data-sources/machine_configuration) | data source |
+| [talos_machine_configuration.worker_mc](https://registry.terraform.io/providers/siderolabs/talos/latest/docs/data-sources/machine_configuration) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_control_machine_config_patches"></a> [control\_machine\_config\_patches](#input\_control\_machine\_config\_patches) | List of YAML patches to apply to the control machine configuration | `list(string)` | <pre>[<br/>  "machine:\n  install:\n    disk: \"/dev/vda\"\n"<br/>]</pre> | no |
+| <a name="input_control_nodes"></a> [control\_nodes](#input\_control\_nodes) | Map of talos control node names to proxmox node names | `map(string)` | n/a | yes |
+| <a name="input_proxmox_control_vm_cores"></a> [proxmox\_control\_vm\_cores](#input\_proxmox\_control\_vm\_cores) | Number of CPU cores for the control VMs | `number` | `4` | no |
+| <a name="input_proxmox_control_vm_disk_size"></a> [proxmox\_control\_vm\_disk\_size](#input\_proxmox\_control\_vm\_disk\_size) | Proxmox control VM disk size in GB | `number` | `32` | no |
+| <a name="input_proxmox_control_vm_memory"></a> [proxmox\_control\_vm\_memory](#input\_proxmox\_control\_vm\_memory) | Memory in MB for the control VMs | `number` | `4096` | no |
+| <a name="input_proxmox_image_datastore"></a> [proxmox\_image\_datastore](#input\_proxmox\_image\_datastore) | Datastore to put the VM hard drive images | `string` | `"local-lvm"` | no |
+| <a name="input_proxmox_iso_datastore"></a> [proxmox\_iso\_datastore](#input\_proxmox\_iso\_datastore) | Datastore to put the qcow2 image | `string` | `"local"` | no |
+| <a name="input_proxmox_network_bridge"></a> [proxmox\_network\_bridge](#input\_proxmox\_network\_bridge) | Proxmox network Bridge | `string` | `"vmbr0"` | no |
+| <a name="input_proxmox_network_vlan_id"></a> [proxmox\_network\_vlan\_id](#input\_proxmox\_network\_vlan\_id) | Proxmox network VLAN ID | `number` | `null` | no |
+| <a name="input_proxmox_vm_type"></a> [proxmox\_vm\_type](#input\_proxmox\_vm\_type) | Proxmox emulated CPU type, x86-64-v2-AES recommended | `string` | `"x86-64-v2-AES"` | no |
+| <a name="input_proxmox_worker_vm_cores"></a> [proxmox\_worker\_vm\_cores](#input\_proxmox\_worker\_vm\_cores) | Number of CPU cores for the worker VMs | `number` | `4` | no |
+| <a name="input_proxmox_worker_vm_disk_size"></a> [proxmox\_worker\_vm\_disk\_size](#input\_proxmox\_worker\_vm\_disk\_size) | Proxmox worker VM disk size in GB | `number` | `100` | no |
+| <a name="input_proxmox_worker_vm_memory"></a> [proxmox\_worker\_vm\_memory](#input\_proxmox\_worker\_vm\_memory) | Memory in MB for the worker VMs | `number` | `4096` | no |
+| <a name="input_talos_arch"></a> [talos\_arch](#input\_talos\_arch) | Architecture of Talos to use | `string` | `"amd64"` | no |
+| <a name="input_talos_cluster_name"></a> [talos\_cluster\_name](#input\_talos\_cluster\_name) | Name of the Talos cluster | `string` | n/a | yes |
+| <a name="input_talos_schematic_id"></a> [talos\_schematic\_id](#input\_talos\_schematic\_id) | Schematic ID for the Talos cluster | `string` | `"ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515"` | no |
+| <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | Version of Talos to use | `string` | n/a | yes |
+| <a name="input_worker_extra_disks"></a> [worker\_extra\_disks](#input\_worker\_extra\_disks) | Map of talos worker node name to a list of extra disk blocks for the VMs | <pre>map(list(object({<br/>        datastore_id = string<br/>        size         = number<br/>        file_format  = optional(string)<br/>        file_id      = optional(string)<br/>    })))</pre> | `{}` | no |
+| <a name="input_worker_machine_config_patches"></a> [worker\_machine\_config\_patches](#input\_worker\_machine\_config\_patches) | List of YAML patches to apply to the worker machine configuration | `list(string)` | <pre>[<br/>  "machine:\n  install:\n    disk: \"/dev/vda\"\n"<br/>]</pre> | no |
+| <a name="input_worker_nodes"></a> [worker\_nodes](#input\_worker\_nodes) | Map of talos worker node names to proxmox node names | `map(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Kubeconfig file |
+| <a name="output_talos_config"></a> [talos\_config](#output\_talos\_config) | Talos configuration file |
+<!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,155 +1,155 @@
 # Copyright (c) 2024 BB Tech Systems LLC
 
 locals {
-    primary_control_node_ip = proxmox_virtual_environment_vm.talos_control_vm[keys(var.control_nodes)[0]].ipv4_addresses[7][0]
-    control_node_ips = [for vm in keys(var.control_nodes) : proxmox_virtual_environment_vm.talos_control_vm[vm].ipv4_addresses[7][0]]
-    worker_node_ips = [for vm in keys(var.worker_nodes) : proxmox_virtual_environment_vm.talos_worker_vm[vm].ipv4_addresses[7][0]]
-    node_ips = concat(
-        local.control_node_ips,
-        local.worker_node_ips
-    )
+  primary_control_node_ip = proxmox_virtual_environment_vm.talos_control_vm[keys(var.control_nodes)[0]].ipv4_addresses[7][0]
+  control_node_ips        = [for vm in keys(var.control_nodes) : proxmox_virtual_environment_vm.talos_control_vm[vm].ipv4_addresses[7][0]]
+  worker_node_ips         = [for vm in keys(var.worker_nodes) : proxmox_virtual_environment_vm.talos_worker_vm[vm].ipv4_addresses[7][0]]
+  node_ips = concat(
+    local.control_node_ips,
+    local.worker_node_ips
+  )
 }
 
 resource "proxmox_virtual_environment_download_file" "talos_image" {
-    content_type = "iso"
-    datastore_id = var.proxmox_iso_datastore
-    node_name    = values(var.control_nodes)[0]
-    url          = "https://factory.talos.dev/image/${var.talos_schematic_id}/v${var.talos_version}/metal-${var.talos_arch}.qcow2"
-    file_name    = "${var.talos_cluster_name}-talos_linux-${var.talos_schematic_id}-${var.talos_version}-${var.talos_arch}.img"
+  content_type = "iso"
+  datastore_id = var.proxmox_iso_datastore
+  node_name    = values(var.control_nodes)[0]
+  url          = "https://factory.talos.dev/image/${var.talos_schematic_id}/v${var.talos_version}/metal-${var.talos_arch}.qcow2"
+  file_name    = "${var.talos_cluster_name}-talos_linux-${var.talos_schematic_id}-${var.talos_version}-${var.talos_arch}.img"
 }
 
 resource "proxmox_virtual_environment_vm" "talos_control_vm" {
-    for_each  = var.control_nodes
-    name      = each.key
-    node_name = each.value
-    agent {
-        enabled = true
-    }
-    cpu {
-        cores = var.proxmox_control_vm_cores
-        type  = var.proxmox_vm_type
-    }
-    memory {
-        dedicated = var.proxmox_control_vm_memory
-        floating  = var.proxmox_control_vm_memory
-    }
-    disk {
-        datastore_id = var.proxmox_image_datastore
-        file_id      = proxmox_virtual_environment_download_file.talos_image.id
-        interface    = "virtio0"
-        iothread     = true
-        discard      = "on"
-        size         = var.proxmox_control_vm_disk_size
-    }
-    network_device {
-        vlan_id = var.proxmox_network_vlan_id
-        bridge  = var.proxmox_network_bridge
-    }
-    operating_system {
-        type = "l26"
-    }
+  for_each  = var.control_nodes
+  name      = each.key
+  node_name = each.value
+  agent {
+    enabled = true
+  }
+  cpu {
+    cores = var.proxmox_control_vm_cores
+    type  = var.proxmox_vm_type
+  }
+  memory {
+    dedicated = var.proxmox_control_vm_memory
+    floating  = var.proxmox_control_vm_memory
+  }
+  disk {
+    datastore_id = var.proxmox_image_datastore
+    file_id      = proxmox_virtual_environment_download_file.talos_image.id
+    interface    = "virtio0"
+    iothread     = true
+    discard      = "on"
+    size         = var.proxmox_control_vm_disk_size
+  }
+  network_device {
+    vlan_id = var.proxmox_network_vlan_id
+    bridge  = var.proxmox_network_bridge
+  }
+  operating_system {
+    type = "l26"
+  }
 }
 
 resource "proxmox_virtual_environment_vm" "talos_worker_vm" {
-    for_each  = var.worker_nodes
-    name      = each.key
-    node_name = each.value
-    agent {
-        enabled = true
+  for_each  = var.worker_nodes
+  name      = each.key
+  node_name = each.value
+  agent {
+    enabled = true
+  }
+  cpu {
+    cores = var.proxmox_worker_vm_cores
+    type  = var.proxmox_vm_type
+  }
+  memory {
+    dedicated = var.proxmox_worker_vm_memory
+    floating  = var.proxmox_worker_vm_memory
+  }
+  disk {
+    datastore_id = var.proxmox_image_datastore
+    file_id      = proxmox_virtual_environment_download_file.talos_image.id
+    interface    = "virtio0"
+    iothread     = true
+    discard      = "on"
+    size         = var.proxmox_worker_vm_disk_size
+  }
+  network_device {
+    vlan_id = var.proxmox_network_vlan_id
+    bridge  = var.proxmox_network_bridge
+  }
+  dynamic "disk" {
+    for_each = lookup(var.worker_extra_disks, each.key, [])
+    content {
+      datastore_id = disk.value.datastore_id
+      file_format  = disk.value.file_format
+      file_id      = disk.value.file_id
+      interface    = "virtio${disk.key + 1}"
+      iothread     = true
+      discard      = "on"
+      size         = disk.value.size
     }
-    cpu {
-        cores = var.proxmox_worker_vm_cores
-        type  = var.proxmox_vm_type
-    }
-    memory {
-        dedicated = var.proxmox_control_vm_memory
-        floating  = var.proxmox_control_vm_memory
-    }
-    disk {
-        datastore_id = var.proxmox_image_datastore
-        file_id      = proxmox_virtual_environment_download_file.talos_image.id
-        interface    = "virtio0"
-        iothread     = true
-        discard      = "on"
-        size         = var.proxmox_worker_vm_disk_size
-    }
-    network_device {
-        vlan_id = var.proxmox_network_vlan_id
-        bridge  = var.proxmox_network_bridge
-    }
-    dynamic "disk" {
-        for_each = lookup(var.worker_extra_disks, each.key, [])
-        content {
-            datastore_id = disk.value.datastore_id
-            file_format  = disk.value.file_format
-            file_id      = disk.value.file_id
-            interface    = "virtio${disk.key+1}"
-            iothread     = true
-            discard      = "on"
-            size         = disk.value.size
-        }
 
-    }
-    operating_system {
-        type = "l26"
-    }
+  }
+  operating_system {
+    type = "l26"
+  }
 }
 
 resource "talos_machine_secrets" "talos_secrets" {}
 
 data "talos_machine_configuration" "control_mc" {
-    cluster_name     = var.talos_cluster_name
-    machine_type     = "controlplane"
-    # TODO - Should we allow the user to override this?
-    # This is a single point of failure but without a proxy or load balancer
-    # it is required to be a single point of failure.
-    cluster_endpoint = "https://${local.primary_control_node_ip}:6443"
-    machine_secrets  = talos_machine_secrets.talos_secrets.machine_secrets
+  cluster_name = var.talos_cluster_name
+  machine_type = "controlplane"
+  # TODO - Should we allow the user to override this?
+  # This is a single point of failure but without a proxy or load balancer
+  # it is required to be a single point of failure.
+  cluster_endpoint = "https://${local.primary_control_node_ip}:6443"
+  machine_secrets  = talos_machine_secrets.talos_secrets.machine_secrets
 }
 
 data "talos_machine_configuration" "worker_mc" {
-    cluster_name     = var.talos_cluster_name
-    machine_type     = "worker"
-    # TODO - Should we allow the user to override this?
-    # This is a single point of failure but without a proxy or load balancer
-    # it is required to be a single point of failure.
-    cluster_endpoint = "https://${local.primary_control_node_ip}:6443"
-    machine_secrets  = talos_machine_secrets.talos_secrets.machine_secrets
+  cluster_name = var.talos_cluster_name
+  machine_type = "worker"
+  # TODO - Should we allow the user to override this?
+  # This is a single point of failure but without a proxy or load balancer
+  # it is required to be a single point of failure.
+  cluster_endpoint = "https://${local.primary_control_node_ip}:6443"
+  machine_secrets  = talos_machine_secrets.talos_secrets.machine_secrets
 }
 
 data "talos_client_configuration" "talos_client_config" {
-    cluster_name         = var.talos_cluster_name
-    client_configuration = talos_machine_secrets.talos_secrets.client_configuration
-    endpoints            = local.control_node_ips
-    nodes                = local.node_ips
+  cluster_name         = var.talos_cluster_name
+  client_configuration = talos_machine_secrets.talos_secrets.client_configuration
+  endpoints            = local.control_node_ips
+  nodes                = local.node_ips
 }
 
 resource "talos_machine_configuration_apply" "talos_control_mc_apply" {
-    for_each = var.control_nodes
-    client_configuration        = talos_machine_secrets.talos_secrets.client_configuration
-    machine_configuration_input = data.talos_machine_configuration.control_mc.machine_configuration
-    node                        = proxmox_virtual_environment_vm.talos_control_vm[each.key].ipv4_addresses[7][0]
-    config_patches              = var.control_machine_config_patches
+  for_each                    = var.control_nodes
+  client_configuration        = talos_machine_secrets.talos_secrets.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.control_mc.machine_configuration
+  node                        = proxmox_virtual_environment_vm.talos_control_vm[each.key].ipv4_addresses[7][0]
+  config_patches              = var.control_machine_config_patches
 }
 
 resource "talos_machine_configuration_apply" "talos_worker_mc_apply" {
-    for_each = var.worker_nodes
-    client_configuration        = talos_machine_secrets.talos_secrets.client_configuration
-    machine_configuration_input = data.talos_machine_configuration.worker_mc.machine_configuration
-    node                        = proxmox_virtual_environment_vm.talos_worker_vm[each.key].ipv4_addresses[7][0]
-    config_patches              = var.worker_machine_config_patches
+  for_each                    = var.worker_nodes
+  client_configuration        = talos_machine_secrets.talos_secrets.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.worker_mc.machine_configuration
+  node                        = proxmox_virtual_environment_vm.talos_worker_vm[each.key].ipv4_addresses[7][0]
+  config_patches              = var.worker_machine_config_patches
 }
 
 # You only need to bootstrap 1 control node, we pick the first one
 resource "talos_machine_bootstrap" "talos_bootstrap" {
-    node                 = local.primary_control_node_ip
-    client_configuration = talos_machine_secrets.talos_secrets.client_configuration
+  node                 = local.primary_control_node_ip
+  client_configuration = talos_machine_secrets.talos_secrets.client_configuration
 }
 
 resource "talos_cluster_kubeconfig" "talos_kubeconfig" {
-    depends_on   = [
-        talos_machine_bootstrap.talos_bootstrap
-    ]
-    client_configuration = talos_machine_secrets.talos_secrets.client_configuration
-    node                 = local.primary_control_node_ip
+  depends_on = [
+    talos_machine_bootstrap.talos_bootstrap
+  ]
+  client_configuration = talos_machine_secrets.talos_secrets.client_configuration
+  node                 = local.primary_control_node_ip
 }

--- a/main.tf
+++ b/main.tf
@@ -10,12 +10,13 @@ locals {
   )
 }
 
-resource "proxmox_virtual_environment_download_file" "talos_image" {
+resource "proxmox_download_file" "talos_image" {
   content_type = "iso"
   datastore_id = var.proxmox_iso_datastore
   node_name    = values(var.control_nodes)[0]
   url          = "https://factory.talos.dev/image/${var.talos_schematic_id}/v${var.talos_version}/metal-${var.talos_arch}.qcow2"
   file_name    = "${var.talos_cluster_name}-talos_linux-${var.talos_schematic_id}-${var.talos_version}-${var.talos_arch}.img"
+  overwrite    = false
 }
 
 resource "proxmox_virtual_environment_vm" "talos_control_vm" {
@@ -35,7 +36,7 @@ resource "proxmox_virtual_environment_vm" "talos_control_vm" {
   }
   disk {
     datastore_id = var.proxmox_image_datastore
-    file_id      = proxmox_virtual_environment_download_file.talos_image.id
+    file_id      = proxmox_download_file.talos_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -67,7 +68,7 @@ resource "proxmox_virtual_environment_vm" "talos_worker_vm" {
   }
   disk {
     datastore_id = var.proxmox_image_datastore
-    file_id      = proxmox_virtual_environment_download_file.talos_image.id
+    file_id      = proxmox_download_file.talos_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"


### PR DESCRIPTION
## Summary

- Replace deprecated `proxmox_virtual_environment_download_file` resource with `proxmox_download_file` (the bpg/proxmox provider will remove the old resource in v1.0)
- Add `overwrite = false` to suppress the file-size-changed warning when the Talos image already exists in the datastore

## Test plan

- [ ] `terraform plan` produces no warnings related to the download file resource
- [ ] Existing Talos VMs are not recreated (state migration: `terraform state mv proxmox_virtual_environment_download_file.talos_image proxmox_download_file.talos_image`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)