### PR TITLE
feat: configurable cluster_endpoint and per-node config patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,64 @@ output "kubeconfig" {
 }
 ```
 
+## High-availability control plane endpoint (VIP)
+
+By default the cluster endpoint points at the first control node's IP, which is a
+single point of failure. To make it highly available, set `cluster_endpoint` to a
+shared [Talos VIP](https://www.talos.dev/latest/talos-guides/network/vip/) and
+define that VIP on the control nodes via a config patch:
+
+```terraform
+module "talos" {
+  source  = "bbtechsys/talos/proxmox"
+  # ... cluster_name, version, nodes ...
+
+  cluster_endpoint = "https://192.168.88.200:6443" # shared VIP
+
+  control_machine_config_patches = [
+    yamlencode({
+      machine = {
+        install = { disk = "/dev/vda" }
+        network = {
+          interfaces = [{
+            interface = "eth0"
+            dhcp      = true
+            vip       = { ip = "192.168.88.200" }
+          }]
+        }
+      }
+    })
+  ]
+}
+```
+
+`cluster_endpoint` defaults to `null` (legacy first-node behavior), so this change
+is fully backward compatible.
+
+## Per-node configuration patches
+
+`control_node_config_patches` and `worker_node_config_patches` are maps keyed by
+node name. Their patches are appended *after* the shared
+`control_machine_config_patches` / `worker_machine_config_patches`, so they can
+override shared values — useful for per-node tuning such as kubelet args or node
+labels:
+
+```terraform
+  worker_node_config_patches = {
+    "test-worker-0" = [yamlencode({
+      machine = { kubelet = { extraArgs = { "node-labels" = "gpu=true" } } }
+    })]
+  }
+```
+
+Both default to `{}`, so they are backward compatible.
+
+> Note: avoid using these to set static node IPs via `dhcp: false`. This module
+> discovers node IPs through the guest agent and assumes they are stable, so a
+> static-address patch can change a node's IP out from under that discovery (or
+> strand the node). For predictable IPs, pin a `mac_address` and use a DHCP
+> reservation instead.
+
 Check out our [blog post](https://bbtechsystems.com/blog/k8s-with-pxe-tf/) for more details on using this module.
 
 Copyright (c) 2024 BB Tech Systems LLC

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,9 @@ locals {
         local.control_node_ips,
         local.worker_node_ips
     )
+    # Defaults to the first control node's IP for backward compatibility.
+    # Set var.cluster_endpoint to a VIP or load balancer for an HA endpoint.
+    cluster_endpoint = coalesce(var.cluster_endpoint, "https://${local.primary_control_node_ip}:6443")
 }
 
 resource "proxmox_virtual_environment_download_file" "talos_image" {
@@ -104,20 +107,18 @@ resource "talos_machine_secrets" "talos_secrets" {}
 data "talos_machine_configuration" "control_mc" {
     cluster_name     = var.talos_cluster_name
     machine_type     = "controlplane"
-    # TODO - Should we allow the user to override this?
-    # This is a single point of failure but without a proxy or load balancer
-    # it is required to be a single point of failure.
-    cluster_endpoint = "https://${local.primary_control_node_ip}:6443"
+    # Override via var.cluster_endpoint (e.g. a VIP) for an HA endpoint;
+    # otherwise defaults to the first control node's IP (a single point of failure).
+    cluster_endpoint = local.cluster_endpoint
     machine_secrets  = talos_machine_secrets.talos_secrets.machine_secrets
 }
 
 data "talos_machine_configuration" "worker_mc" {
     cluster_name     = var.talos_cluster_name
     machine_type     = "worker"
-    # TODO - Should we allow the user to override this?
-    # This is a single point of failure but without a proxy or load balancer
-    # it is required to be a single point of failure.
-    cluster_endpoint = "https://${local.primary_control_node_ip}:6443"
+    # Override via var.cluster_endpoint (e.g. a VIP) for an HA endpoint;
+    # otherwise defaults to the first control node's IP (a single point of failure).
+    cluster_endpoint = local.cluster_endpoint
     machine_secrets  = talos_machine_secrets.talos_secrets.machine_secrets
 }
 
@@ -133,7 +134,10 @@ resource "talos_machine_configuration_apply" "talos_control_mc_apply" {
     client_configuration        = talos_machine_secrets.talos_secrets.client_configuration
     machine_configuration_input = data.talos_machine_configuration.control_mc.machine_configuration
     node                        = proxmox_virtual_environment_vm.talos_control_vm[each.key].ipv4_addresses[7][0]
-    config_patches              = var.control_machine_config_patches
+    config_patches              = concat(
+        var.control_machine_config_patches,
+        lookup(var.control_node_config_patches, each.key, [])
+    )
 }
 
 resource "talos_machine_configuration_apply" "talos_worker_mc_apply" {
@@ -141,7 +145,10 @@ resource "talos_machine_configuration_apply" "talos_worker_mc_apply" {
     client_configuration        = talos_machine_secrets.talos_secrets.client_configuration
     machine_configuration_input = data.talos_machine_configuration.worker_mc.machine_configuration
     node                        = proxmox_virtual_environment_vm.talos_worker_vm[each.key].ipv4_addresses[7][0]
-    config_patches              = var.worker_machine_config_patches
+    config_patches              = concat(
+        var.worker_machine_config_patches,
+        lookup(var.worker_node_config_patches, each.key, [])
+    )
 }
 
 # You only need to bootstrap 1 control node, we pick the first one

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,17 @@ variable "talos_cluster_name" {
     type        = string
 }
 
+variable "cluster_endpoint" {
+    # When null, the endpoint defaults to https://<first control node IP>:6443,
+    # which is a single point of failure. Set this to a shared VIP or a
+    # load-balancer/proxy address (e.g. https://10.0.0.10:6443) for an HA endpoint.
+    # If using a Talos shared VIP, also define it via control_machine_config_patches
+    # or control_node_config_patches (machine.network.interfaces[].vip.ip).
+    description = "Kubernetes API cluster endpoint (e.g. https://<vip>:6443). Defaults to the first control node's IP."
+    type        = string
+    default     = null
+}
+
 variable "proxmox_control_pool_id" {
     description = "Proxmox control VM pool ID"
     type = string
@@ -161,6 +172,28 @@ machine:
     disk: "/dev/vda"
 EOT
     ]
+}
+
+variable "control_node_config_patches" {
+    # Patches here are appended AFTER control_machine_config_patches, so they can
+    # override shared values. Use for per-node settings such as static addresses
+    # (machine.network.interfaces[].addresses) or hostnames.
+    # Example:
+    # control_node_config_patches = {
+    #   "talos-control-0" = [yamlencode({ machine = { network = { hostname = "cp0" } } })]
+    # }
+    description = "Map of control node name to a list of extra YAML patches applied after the shared control patches"
+    type        = map(list(string))
+    default     = {}
+    nullable    = false
+}
+
+variable "worker_node_config_patches" {
+    # Patches here are appended AFTER worker_machine_config_patches.
+    description = "Map of worker node name to a list of extra YAML patches applied after the shared worker patches"
+    type        = map(list(string))
+    default     = {}
+    nullable    = false
 }
 
 variable "worker_extra_disks" {


### PR DESCRIPTION
Add backward-compatible options for HA control-plane endpoints and per-node Talos machine configuration:

Override the Kubernetes API endpoint - a shared Talos VIP instead of the
 hardcoded first-control-node IP. This resolves the single point of failure noted 
in the existing TODO comments. When unset, the endpoint falls back to the first 
control node's IP exactly as before.

### control_node_config_patches / worker_node_config_patches (default {})
Per-node patch lists, concatenated after the existing shared patches, for
per-node tuning such as kubelet args or node labels. Empty maps = no change.

### Notes
- README documents both, including a caution against using per-node patches for
  static IPs via `dhcp: false` (it fights the guest-agent IP discovery); the
  `mac_address` + DHCP reservation path is recommended for predictable IPs.
- Validated on a live 3+3 Talos cluster: cluster_endpoint pointed at a Talos VIP,
  HA confirmed via failover (killed the VIP holder, kube API stayed reachable).
